### PR TITLE
Add new OpenRouter models: Grok Code Fast 1, Claude Sonnet 4, DeepSeek Chat V3.1 Free

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superdesign",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superdesign",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.12",
         "@ai-sdk/google": "^1.2.19",

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -193,6 +193,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'claude-4-opus-20250514': 'Claude 4 Opus',
             'claude-4-sonnet-20250514': 'Claude 4 Sonnet',
             'claude-3-7-sonnet-20250219': 'Claude 3.7 Sonnet',
+            'anthropic/claude-sonnet-4': 'Claude Sonnet 4',
             'claude-3-5-sonnet-20241022': 'Claude 3.5 Sonnet',
             'claude-3-opus-20240229': 'Claude 3 Opus',
             'claude-3-sonnet-20240229': 'Claude 3 Sonnet',
@@ -240,6 +241,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'deepseek/deepseek-r1-distill-qwen-7b': 'DeepSeek R1 Distill Qwen 7B',
             'deepseek/deepseek-r1-distill-qwen-1.5b': 'DeepSeek R1 Distill Qwen 1.5B',
             'deepseek/deepseek-chat-v3': 'DeepSeek Chat V3',
+            'deepseek/deepseek-chat-v3.1:free': 'DeepSeek Chat V3.1 Free',
             'deepseek/deepseek-v3-base': 'DeepSeek V3 Base',
             'deepseek/deepseek-prover-v2': 'DeepSeek Prover V2',
             // OpenRouter - Mistral models
@@ -271,6 +273,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'x-ai/grok-2-vision-1212': 'Grok 2 Vision',
             'x-ai/grok-2-1212': 'Grok 2',
             'x-ai/grok-vision-beta': 'Grok Vision Beta',
+            'x-ai/grok-code-fast-1': 'Grok Code Fast 1',
             // OpenRouter - Qwen models
             'qwen/qwen3-235b-a22b-04-28': 'Qwen3 235B',
             'qwen/qwen3-32b-04-28': 'Qwen3 32B',

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -53,6 +53,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         { id: 'inflection/inflection-3-productivity', name: 'Inflection 3 Productivity', provider: 'OpenRouter (Inflection)', category: 'Balanced' },
         // Reka (OpenRouter)
         { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
+        // Additional OpenRouter models
+        { id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast 1', provider: 'OpenRouter (xAI)', category: 'Fast' },
+        { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4', provider: 'OpenRouter (Anthropic)', category: 'Balanced' },
+        { id: 'deepseek/deepseek-chat-v3.1:free', name: 'DeepSeek Chat V3.1 Free', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
         // Existing OpenAI (direct)
         { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
         { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }


### PR DESCRIPTION
This PR adds three additional OpenRouter models to the SuperDesign extension for enhanced AI capabilities:

- x-ai/grok-code-fast-1 (Grok Code Fast 1) - Fast coding assistant from xAI.
- anthropic/claude-sonnet-4 (Claude Sonnet 4) - Balanced model from Anthropic via OpenRouter.
- deepseek/deepseek-chat-v3.1:free (DeepSeek Chat V3.1 Free) - Free, high-performance chat model from DeepSeek.

Changes:
- Updated ModelSelector.tsx to include these in the dropdown options.
- Added display names in chatSidebarProvider.ts's getModelDisplayName() for proper UI rendering.
- No other changes needed as the CustomAgentService uses aiModel config dynamically.

Tested:
- Models appear in the selector and can be selected.
- OpenRouter API key is used correctly (verified in logs).
- Chat responses generate successfully with the new models.
- Error handling works if API key is invalid.

This expands model choices without breaking existing functionality. Let me know if you'd like any other model to be added