### PR TITLE
feature: Implement logic for 'Add Context' button

### DIFF
--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -90,6 +90,26 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                     case 'changeProvider':
                         await this.handleChangeProvider(message.model, webviewView.webview);
                         break;
+                    case 'addContext':
+                        const options: vscode.OpenDialogOptions = {
+                            canSelectMany: false,
+                            openLabel: 'Select File',
+                            canSelectFiles: true,
+                            canSelectFolders: false
+                        };
+                
+                        vscode.window.showOpenDialog(options).then(fileUri => {
+                            if (fileUri && fileUri[0]) {
+                                webviewView.webview.postMessage({
+                                    command: 'contextFromCanvas',
+                                    data: {
+                                        fileName: fileUri[0].fsPath,
+                                        type: 'file'
+                                    }
+                                });
+                            }
+                        });
+                        break;
                 }
             }
         );

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -352,8 +352,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
     }, [inputMessage]);
 
     const handleAddContext = () => {
-        // TODO: Implement context addition functionality
-        console.log('Add Context clicked');
+        vscode.postMessage({
+            command: 'addContext'
+        });
     };
 
     const handleNewConversation = () => {


### PR DESCRIPTION
This commit wires up the 'Add Context' button in the chat interface.

- The button in ChatInterface.tsx now sends a 'addContext' message to the extension.

- The chatSidebarProvider.ts now handles this message by opening a file selection dialog, allowing users to select a file to add as context to the conversation.