### PR TITLE
Add support for custom Anthropic API URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
           "description": "Anthropic API key for Claude Code integration (required for claude-api provider)",
           "scope": "application"
         },
+        "superdesign.anthropicUrl": {
+          "type": "string",
+          "description": "Custom Anthropic API URL (for local proxies like localhost:4000)",
+          "scope": "application"
+        },
         "superdesign.claudeCodePath": {
           "type": "string",
           "description": "Path to claude binary (defaults to 'claude' for npm install, use 'claude-code' if installed via shell script)",

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -128,13 +128,23 @@ export class CustomAgentService implements AgentService {
                 }
                 
                 this.outputChannel.appendLine(`Anthropic API key found: ${anthropicKey.substring(0, 12)}...`);
-                
+
+                const anthropicUrl = config.get<string>('anthropicUrl');
+                const isCustomAnthropicUrl = !!anthropicUrl;
+
+                if (isCustomAnthropicUrl) {
+                    this.outputChannel.appendLine(`Using custom Anthropic URL: ${anthropicUrl}`);
+                }
+
                 const anthropic = createAnthropic({
                     apiKey: anthropicKey,
-                    baseURL: "https://anthropic.helicone.ai/v1",
-                    headers: {
-                        "Helicone-Auth": `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
-                    }
+                    baseURL: anthropicUrl || "https://anthropic.helicone.ai/v1",
+                    // Only include Helicone headers when using default URL
+                    ...(isCustomAnthropicUrl ? {} : {
+                        headers: {
+                            "Helicone-Auth": `Bearer sk-helicone-utidjzi-eprey7i-tvjl25y-yl7mosi`,
+                        }
+                    })
                 });
                 
                 // Use specific model if available, otherwise default to claude-4-sonnet


### PR DESCRIPTION
## Summary
This PR adds support for custom Anthropic API URLs, allowing users to use local proxies or custom API endpoints for development and testing.

## Changes
- ✨ New configuration setting: `superdesign.anthropicUrl`
- 🔧 Updated `customAgentService.ts` to support custom URLs
- 🛡️ Conditional Helicone header inclusion (only for default URL)

## Use Cases
1. **Local Development** - Use with ccproxy-api or similar local Claude API proxies
2. **Testing** - Test with custom API endpoints
3. **Debugging** - Monitor API calls through local proxy
4. **Alternative Tracking** - Use different analytics/tracking services

## How It Works

### Configuration
Users can add to their VS Code settings:
```json
{
  "superdesign.anthropicUrl": "http://localhost:4000"
}
```

### Behavior
- **Without custom URL:** Uses default `https://anthropic.helicone.ai/v1` with Helicone headers
- **With custom URL:** Uses specified URL without Helicone headers (assumes custom proxy handles its own auth/tracking)

## Implementation Details
- Read `anthropicUrl` from workspace configuration
- Conditionally construct `createAnthropic` options based on presence of custom URL
- Log custom URL usage for debugging
- No breaking changes - fully backward compatible

## Code Changes
**package.json:**
- Added `superdesign.anthropicUrl` configuration property

**src/services/customAgentService.ts:**
- Read custom URL from config
- Use custom URL if provided, otherwise default to Helicone
- Conditionally include Helicone auth headers only when using default endpoint
- Added logging for custom URL usage

## Testing
✅ TypeScript compilation passes
✅ Backward compatible (no custom URL = existing behavior)
✅ Code follows existing patterns
⏳ Manual testing with local proxy recommended

## Benefits
- Enables use of local Claude API proxies like ccproxy-api
- Allows testing with custom endpoints
- Provides flexibility for different deployment scenarios
- Maintains full backward compatibility

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>