### PR TITLE
feat: add Vercel AI Gateway provider support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "superdesign",
-  "version": "0.0.11",
+  "name": "superdesign-official",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "superdesign",
-      "version": "0.0.11",
+      "name": "superdesign-official",
+      "version": "0.0.14",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.12",
         "@ai-sdk/google": "^1.2.19",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
         "category": "Superdesign"
       },
       {
+        "command": "superdesign.configureVercelAiGatewayApiKey",
+        "title": "Configure Vercel AI Gateway API Key",
+        "category": "Superdesign"
+      },
+      {
         "command": "superdesign.showChatSidebar",
         "title": "Show Chat Sidebar",
         "category": "Superdesign"
@@ -205,12 +210,18 @@
           "description": "OpenRouter API key for custom agent",
           "scope": "application"
         },
+        "superdesign.vercelAiGatewayApiKey": {
+          "type": "string",
+          "description": "Vercel AI Gateway API key",
+          "scope": "application"
+        },
         "superdesign.aiModelProvider": {
           "type": "string",
           "enum": [
             "openai",
             "anthropic",
             "openrouter",
+            "vercel-ai-gateway",
             "claude-code"
           ],
           "default": "anthropic",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1274,6 +1274,10 @@ export function activate(context: vscode.ExtensionContext) {
 		await configureOpenRouterApiKey();
 	});
 
+	const configureVercelAiGatewayApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureVercelAiGatewayApiKey', async () => {
+		await configureVercelAiGatewayApiKey();
+	});
+
   const configureOpenAIUrlDisposable = vscode.commands.registerCommand('superdesign.configureOpenAIUrl', async () => {
     await configureOpenAIUrl();
   });
@@ -1395,6 +1399,7 @@ export function activate(context: vscode.ExtensionContext) {
 		configureApiKeyDisposable,
 		configureOpenAIApiKeyDisposable,
 		configureOpenRouterApiKeyDisposable,
+		configureVercelAiGatewayApiKeyDisposable,
     configureOpenAIUrlDisposable,
 		sidebarDisposable,
 		showSidebarDisposable,
@@ -1531,6 +1536,45 @@ async function configureOpenRouterApiKey() {
 					vscode.ConfigurationTarget.Global
 				);
 				vscode.window.showInformationMessage('✅ OpenRouter API key configured successfully!');
+			} catch (error) {
+				vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
+			}
+		} else if (currentKey) {
+			vscode.window.showInformationMessage('API key unchanged (already configured)');
+		} else {
+			vscode.window.showWarningMessage('No API key was set');
+		}
+	}
+}
+
+// Function to configure Vercel AI Gateway API key
+async function configureVercelAiGatewayApiKey() {
+	const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('vercelAiGatewayApiKey');
+
+	const input = await vscode.window.showInputBox({
+		title: 'Configure Vercel AI Gateway API Key',
+		prompt: 'Enter your Vercel AI Gateway API key',
+		value: currentKey ? '••••••••••••••••' : '',
+		password: true,
+		placeHolder: 'your-vercel-api-key',
+		validateInput: (value) => {
+			if (!value || value.trim().length === 0) {
+				return 'API key cannot be empty';
+			}
+			if (value === '••••••••••••••••') {
+				return null;
+			}
+			return null;
+		}
+	});
+
+	if (input !== undefined) {
+		if (input !== '••••••••••••••••') {
+			try {
+				await vscode.workspace
+					.getConfiguration('superdesign')
+					.update('vercelAiGatewayApiKey', input.trim(), vscode.ConfigurationTarget.Global);
+				vscode.window.showInformationMessage('✅ Vercel AI Gateway API key configured successfully!');
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
 			}

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -88,7 +88,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                         await this.handleGetCurrentProvider(webviewView.webview);
                         break;
                     case 'changeProvider':
-                        await this.handleChangeProvider(message.model, webviewView.webview);
+                        await this.handleChangeProvider(message.model, message.provider, webviewView.webview);
                         break;
                 }
             }
@@ -109,6 +109,9 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             case 'openrouter':
                 defaultModel = 'anthropic/claude-3-7-sonnet-20250219';
                 break;
+            case 'vercel-ai-gateway':
+                defaultModel = 'anthropic/claude-sonnet-4.5';
+                break;
             case 'anthropic':
             default:
                 defaultModel = 'claude-4-sonnet-20250514';
@@ -122,17 +125,21 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
         });
     }
 
-    private async handleChangeProvider(model: string, webview: vscode.Webview) {
+    private async handleChangeProvider(model: string, uiProvider: string, webview: vscode.Webview) {
         try {
             const config = vscode.workspace.getConfiguration('superdesign');
-            
-            // Determine provider and API key based on model
+
             let provider: string;
             let apiKeyKey: string;
             let configureCommand: string;
             let displayName: string;
-            
-            if (model.includes('/')) {
+
+            if (uiProvider === 'Vercel AI Gateway') {
+                provider = 'vercel-ai-gateway';
+                apiKeyKey = 'vercelAiGatewayApiKey';
+                configureCommand = 'superdesign.configureVercelAiGatewayApiKey';
+                displayName = `Vercel AI Gateway (${this.getModelDisplayName(model)})`;
+            } else if (model.includes('/')) {
                 // OpenRouter model (contains slash like "openai/gpt-4o")
                 provider = 'openrouter';
                 apiKeyKey = 'openrouterApiKey';

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -138,7 +138,7 @@ export class ChatMessageService {
                 let providerName = 'AI';
                 let configureCommand = 'superdesign.configureApiKey';
                 
-                if (specificModel && !(!openaiUrl && provider === 'openai')) {
+                if (specificModel && !(!openaiUrl && provider === 'openai') && provider !== 'vercel-ai-gateway') {
                     if (specificModel.includes('/')) {
                         effectiveProvider = 'openrouter';
                     } else if (specificModel.startsWith('claude-')) {
@@ -147,7 +147,7 @@ export class ChatMessageService {
                         effectiveProvider = 'openai';
                     }
                 }
-                
+
                 switch (effectiveProvider) {
                     case 'openrouter':
                         providerName = 'OpenRouter';
@@ -160,6 +160,10 @@ export class ChatMessageService {
                     case 'claude-code':
                         providerName = 'Claude Code';
                         configureCommand = 'workbench.action.openSettings';
+                        break;
+                    case 'vercel-ai-gateway':
+                        providerName = 'Vercel AI Gateway';
+                        configureCommand = 'superdesign.configureVercelAiGatewayApiKey';
                         break;
                     case 'openai':
                         providerName = 'OpenAI';

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { AgentService, ExecutionContext } from '../types/agent';
 import { ClaudeCodeService } from './claudeCodeService';
+import { resolveVercelModelId } from './vercelGatewayModelsService';
 import { createReadTool } from '../tools/read-tool';
 import { createWriteTool } from '../tools/write-tool';
 import { createBashTool } from '../tools/bash-tool';
@@ -80,7 +81,7 @@ export class CustomAgentService implements AgentService {
         }
     }
 
-    private getModel() {
+    private async getModel() {
         const config = vscode.workspace.getConfiguration('superdesign');
         const specificModel = config.get<string>('aiModel');
         const provider = config.get<string>('aiModelProvider', 'anthropic');
@@ -93,7 +94,7 @@ export class CustomAgentService implements AgentService {
         
         // Determine provider from model name if specific model is set, ignore if custom openai url is used
         let effectiveProvider = provider;
-        if (specificModel && !(!openaiUrl && provider === 'openai')) {
+        if (specificModel && !(!openaiUrl && provider === 'openai') && provider !== 'vercel-ai-gateway') {
             if (specificModel.includes('/')) {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
@@ -155,7 +156,25 @@ export class CustomAgentService implements AgentService {
             case 'claude-code':
                 // This case is handled in the query method before reaching this point
                 throw new Error('Claude Code provider should be handled before getModel() is called');
-                
+
+            case 'vercel-ai-gateway':
+                const vercelKey = config.get<string>('vercelAiGatewayApiKey');
+                if (!vercelKey) {
+                    throw new Error('Vercel AI Gateway API key not configured. Please run "Configure Vercel AI Gateway API Key" command.');
+                }
+
+                this.outputChannel.appendLine(`Vercel AI Gateway key found: ${vercelKey.substring(0, 12)}...`);
+
+                const vercelGateway = createOpenAI({
+                    apiKey: vercelKey,
+                    baseURL: 'https://ai-gateway.vercel.sh/v1',
+                });
+
+                const rawVercelModel = specificModel || 'anthropic/claude-sonnet-4.5';
+                const vercelModel = await resolveVercelModelId(rawVercelModel);
+                this.outputChannel.appendLine(`Using Vercel AI Gateway model: ${vercelModel}`);
+                return vercelGateway(vercelModel);
+
             case 'openai':
             default:
                 const openaiKey = config.get<string>('openaiApiKey');
@@ -198,6 +217,9 @@ export class CustomAgentService implements AgentService {
                     break;
                 case 'openrouter':
                     modelName = 'anthropic/claude-3-7-sonnet-20250219';
+                    break;
+                case 'vercel-ai-gateway':
+                    modelName = 'anthropic/claude-sonnet-4.5';
                     break;
                 case 'claude-code':
                     modelName = 'claude-code';
@@ -682,7 +704,7 @@ I've created the html design, please reveiw and let me know if you need any chan
 
             // Prepare AI SDK input based on available data
             const streamTextConfig: any = {
-                model: this.getModel(),
+                model: await this.getModel(),
                 system: this.getSystemPrompt(),
                 tools: tools,
                 toolCallStreaming: true,
@@ -975,6 +997,8 @@ I've created the html design, please reveiw and let me know if you need any chan
                 return !!config.get<string>('anthropicApiKey');
             case 'claude-code':
                 return true; // Claude Code doesn't require an API key
+            case 'vercel-ai-gateway':
+                return !!config.get<string>('vercelAiGatewayApiKey');
             case 'openai':
             default:
                 return !!config.get<string>('openaiApiKey');

--- a/src/services/vercelGatewayModelsService.ts
+++ b/src/services/vercelGatewayModelsService.ts
@@ -1,0 +1,29 @@
+const GATEWAY_MODELS_URL = 'https://ai-gateway.vercel.sh/v1/models?include_mappings';
+
+let cachedMapping: Map<string, string> | null = null;
+
+async function fetchModelMapping(): Promise<Map<string, string>> {
+    const response = await fetch(GATEWAY_MODELS_URL);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch Vercel AI Gateway models: ${response.statusText}`);
+    }
+
+    const data = await response.json() as { data: { id: string; compat_id: string[] }[] };
+    const mapping = new Map<string, string>();
+
+    for (const model of data.data) {
+        for (const compatId of (model.compat_id ?? [])) {
+            mapping.set(compatId, model.id);
+        }
+    }
+
+    return mapping;
+}
+
+export async function resolveVercelModelId(modelId: string): Promise<string> {
+    if (!cachedMapping) {
+        cachedMapping = await fetchModelMapping();
+    }
+
+    return cachedMapping.get(modelId) ?? modelId;
+}

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -72,11 +72,12 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
         return () => window.removeEventListener('message', handleMessage);
     }, []);
 
-    const handleModelChange = (model: string) => {
+    const handleModelChange = (model: string, provider: string) => {
         // Send model change request to extension
         vscode.postMessage({
             command: 'changeProvider',
-            model: model
+            model: model,
+            provider: provider
         });
     };
 

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -3,7 +3,7 @@ import { BrainIcon } from '../Icons';
 
 interface ModelSelectorProps {
     selectedModel: string;
-    onModelChange: (model: string) => void;
+    onModelChange: (model: string, provider: string) => void;
     disabled?: boolean;
 }
 
@@ -59,7 +59,20 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         { id: 'deepseek/deepseek-chat-v3.1:free', name: 'DeepSeek Chat V3.1 Free', provider: 'OpenRouter (DeepSeek)', category: 'Balanced' },
         // Existing OpenAI (direct)
         { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
-        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
+        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' },
+        // Vercel AI Gateway
+        { id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'anthropic/claude-opus-4.6', name: 'Claude Opus 4.6', provider: 'Vercel AI Gateway', category: 'Premium' },
+        { id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'openai/gpt-5', name: 'GPT-5', provider: 'Vercel AI Gateway', category: 'Premium' },
+        { id: 'openai/gpt-4.1', name: 'GPT-4.1', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'openai/gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'google/gemini-3-pro-preview', name: 'Gemini 3 Pro', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'meta/llama-4-maverick', name: 'Llama 4 Maverick', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'deepseek/deepseek-r1', name: 'DeepSeek R1', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'xai/grok-3', name: 'Grok 3', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'mistral/magistral-small', name: 'Magistral Small', provider: 'Vercel AI Gateway', category: 'Balanced' },
+        { id: 'alibaba/qwen-3-235b', name: 'Qwen3 235B', provider: 'Vercel AI Gateway', category: 'Balanced' }
     ];
 
     const filteredModels = models.filter(model =>
@@ -134,8 +147,8 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         };
     }, [isOpen]);
 
-    const handleModelSelect = (modelId: string) => {
-        onModelChange(modelId);
+    const handleModelSelect = (modelId: string, provider: string) => {
+        onModelChange(modelId, provider);
         setIsOpen(false);
     };
 
@@ -415,7 +428,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
                                     <button
                                         key={model.id}
                                         className={`model-option ${model.id === selectedModel ? 'selected' : ''}`}
-                                        onClick={() => handleModelSelect(model.id)}
+                                        onClick={() => handleModelSelect(model.id, model.provider)}
                                     >
                                         <div className="model-icon">
                                             <BrainIcon />


### PR DESCRIPTION
## What changed
- Added `vercel-ai-gateway` as a new provider option
- New `Configure Vercel AI Gateway API Key` command
- New `vercelGatewayModelsService.ts` — fetches gateway model list once, caches it, and resolves OpenRouter-style compat IDs to gateway IDs
- Added a small selection of models to the model selector UI
- Flow provider from UI to business logic so provider detection is explicit, so model IDs with "/" will not be detected as other providers when a desired provider is set 

## Testing
- Tested setting new Vercel AI Gateway Provider
- Tested conversations with multiple models via Gateway
